### PR TITLE
Add test for #2

### DIFF
--- a/tests/review.t
+++ b/tests/review.t
@@ -35,6 +35,12 @@ We can also install these updates automatically:
   $ pip-review
   cElementTree==* is available (you have 1.0.5.post20051216) (glob)
 
+Next, let's test for regressions with older versions of pip:
+
+  $ pip install --force-reinstall --upgrade pip\<6.0 >/dev/null 2>&1
+  $ pip-review
+  cElementTree==* is available (you have 1.0.5.post20051216) (glob)
+
 Cleanup our playground:
 
   $ rm -rf FOO


### PR DESCRIPTION
Add a test that installs pip<6.0 to trigger the error with older pip versions, verifies that #2 exists and will pass when it's resolved. Probably shouldn't merge this until it's fixed unless you don't mind the builds failing :)