### PR TITLE
Exit without raising KeyboardInterrupt

### DIFF
--- a/bin/pip-review
+++ b/bin/pip-review
@@ -291,4 +291,8 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.stdout.write('\nAborted\n')
+        sys.exit(0)


### PR DESCRIPTION
Exit cleanly on `KeyboardInterrupt` instead of raising exception.