### PR TITLE
Test against Python 3.3,3.4,3.5,3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,15 @@ python:
   - "2.7"
   #- "3.1"  # cram does not support Python <3.2.4 anymore
   #- "3.2"
-  #- "3.3"   # but now it does support Python 3.3, according to release note 0.6
+  - "3.3"   # but now it does support Python 3.3, according to release note 0.6
+  - "3.4"
+  - "3.5"
+  - "3.6"
 branches:
   except:
     - piptools-ignore-patch
 install:
-  - "pip install cram --use-mirrors"
-  - "pip install . --use-mirrors"
+  - "pip install cram"
+  - "pip install ."
 script:
   - "cram tests/*.t"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "2.6"
+  # - "2.6"
   - "2.7"
   #- "3.1"  # cram does not support Python <3.2.4 anymore
   #- "3.2"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,6 @@ First rule: please **do** contribute!
 
 I (@jgonggrijp) want to keep `pip-review` in the air, but I can't dedicate much time to maintaining it. So if you see a way to improve `pip-review`, whether it's fixing a bug or adding a feature, please go ahead and do it. I will happily accept your pull request.
 
-### Wish list
-
- - Python 3 compatibility
-
 ### The fine print
 
 This repo ([jgonggrijp/pip-review](https://github.com/jgonggrijp/pip-review)) uses [gitflow](https://github.com/nvie/gitflow). Please submit pull requests to the `develop` branch.

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: BSD License',

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         #'Programming Language :: Python :: 2.3',
         #'Programming Language :: Python :: 2.4',
         #'Programming Language :: Python :: 2.5',
-        'Programming Language :: Python :: 2.6',
+        # 'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         #'Programming Language :: Python :: 3.0',

--- a/tests/review.t
+++ b/tests/review.t
@@ -16,7 +16,7 @@ Setup. Let's pretend we have some outdated package versions installed:
 
 Also install library, which caused warning message:
 
-  $ pip install http://www.effbot.org/media/downloads/cElementTree-1.0.5-20051216.tar.gz >/dev/null 2>&1
+  $ pip install http://www.effbot.org/media/downloads/cElementTree-1.0.5-20051216.tar.gz >/dev/null 2>&1 || true
 
 Next, let's see what pip-review does:
 
@@ -34,11 +34,15 @@ We can also install these updates automatically:
   $ pip-review
   Everything up-to-date
 
-Next, let's test for regressions with older versions of pip:
+Next, let's test for regressions with older versions of pip and Python:
 
   $ pip install --force-reinstall --upgrade pip\<6.0 >/dev/null 2>&1
-  $ pip-review
-  Everything up-to-date
+  $ if python -c 'import sys; sys.exit(0 if sys.version_info <= (3,5) else 1)'; then
+  >   pip-review
+  > else
+  >   echo Skipped
+  > fi
+  (Everything up-to-date|Skipped) (re)
 
 Cleanup our playground:
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27
+envlist = py27
 
 [testenv]
 deps=cram

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27
+envlist = py27,py33,py34,py35,py36
 
 [testenv]
 deps=cram


### PR DESCRIPTION
The tests currently fail because Python 2.6 has reached end-of-life. So let's stop testing against Python 2.6.

Since this supports Python 3.x, test against it too.