### PR TITLE
Remove deprecated --use-mirrors arg of pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
   except:
     - piptools-ignore-patch
 install:
-  - "pip install cram --use-mirrors"
-  - "pip install . --use-mirrors"
+  - "pip install cram"
+  - "pip install ."
 script:
   - "cram tests/*.t"


### PR DESCRIPTION
It has been removed as of pip 7.0 and is not really needed.