### PR TITLE
Skip test of pip<6.0 with Python>=3.6

### DIFF
--- a/tests/review.t
+++ b/tests/review.t
@@ -37,8 +37,12 @@ We can also install these updates automatically:
 Next, let's test for regressions with older versions of pip:
 
   $ pip install --force-reinstall --upgrade pip\<6.0 >/dev/null 2>&1
-  $ pip-review
-  Everything up-to-date
+  $ if python -c 'import sys; sys.exit(0 if sys.version_info < (3, 6) else 1)'; then
+  >   pip-review
+  > else
+  >   echo Skipped
+  > fi
+  (Everything up-to-date|Skipped) (re)
 
 Cleanup our playground:
 


### PR DESCRIPTION
pip<6.0 doesn't even install under Python 3.6.

We're not testing against Python 3.x yet, but this is good preparation for it.