### PR TITLE
Ignore Python 2.6 deprecation notice in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install:
   - "pip install cram --use-mirrors"
   - "pip install . --use-mirrors"
 script:
-  - "cram tests/*.t"
+  - "cram --shell=/bin/bash tests/*.t"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-cram tests/*.t
+cram --shell=/bin/bash tests/*.t

--- a/tests/review.t
+++ b/tests/review.t
@@ -18,20 +18,26 @@ Also install library, which caused warning message:
 
   $ pip install http://www.effbot.org/media/downloads/cElementTree-1.0.5-20051216.tar.gz >/dev/null 2>&1
 
+Before our next test, let's just check that the Bash option pipefail works:
+
+  $ set -o pipefail
+  $ false | true
+  [1]
+
 Next, let's see what pip-review does:
 
-  $ pip-review
+  $ pip-review 2>&1 | { grep -v 'DEPRECATION: Python 2.6 is no longer supported' || true; }
   python-dateutil==* is available (you have 1.5) (glob)
 
 Or in raw mode:
 
-  $ pip-review --raw
+  $ pip-review --raw 2>&1 | { grep -v 'DEPRECATION: Python 2.6 is no longer supported' || true; }
   python-dateutil==* (glob)
 
 We can also install these updates automatically:
 
   $ pip-review --auto >/dev/null 2>&1
-  $ pip-review
+  $ pip-review 2>&1 | { grep -v 'DEPRECATION: Python 2.6 is no longer supported' || true; }
   Everything up-to-date
 
 Next, let's test for regressions with older versions of pip:


### PR DESCRIPTION
This should hopefully cause the tests to pass in Travis again! This should fix #15.