### PR TITLE
add requirements.txt in project

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+setuptools
+future
+os
+re
+argparse
+functools
+logging
+json
+sys
+pip
+subprocess
+packaging
+urllib


### PR DESCRIPTION
This feature allows you to quickly install the necessary libraries to run this project (for example, via PyCharm on Ubuntu).