### PR TITLE
test: create a pytest module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ install:
   - "pip install cram"
   - "pip install ."
 script:
-  - "cram --shell=/bin/bash tests/*.t"
   - "pytest"
+  - "cram --shell=/bin/bash tests/*.t"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ branches:
   except:
     - piptools-ignore-patch
 install:
-  - "pip install -U setuptools pip wheel"
+  - "pip install -U setuptools pip wheel pytest"
   - "pip install cram"
   - "pip install ."
 script:
   - "cram --shell=/bin/bash tests/*.t"
+  - "pytest"

--- a/pip_review/__main__.py
+++ b/pip_review/__main__.py
@@ -173,10 +173,10 @@ def update_packages(packages, forwarded, continue_on_fail):
         subprocess.call(upgrade_cmd, stdout=sys.stdout, stderr=sys.stderr)
         return
 
+    upgrade_cmd.append('')
     for pkg in packages:
-        upgrade_cmd += ['{0}'.format(pkg['name'])]
+        upgrade_cmd[-1] = '{0}'.format(pkg['name'])
         subprocess.call(upgrade_cmd, stdout=sys.stdout, stderr=sys.stderr)
-        upgrade_cmd.pop()
 
 
 def confirm(question):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,147 @@
+import subprocess
+from unittest.mock import patch, call, Mock
+from sys import executable as python
+
+from pytest import raises
+
+from pip_review.__main__ import main
+
+
+class FakePopen:
+
+    def __init__(self, stdout=None, stderr=None, returncode=0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return
+
+    def communicate(self):
+        return self.stdout, self.stderr
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self, timeout=None):
+        return self.returncode
+
+
+def outdated_call(forwarded=None):
+    args = [
+        python, '-m', 'pip', 'list', '--outdated', '--disable-pip-version-check', '--format=json'
+    ]
+    if forwarded:
+        args = args[:5] + forwarded + args[5:]
+    return call(args, stdout=subprocess.PIPE)
+
+
+def simulate(sys_argv, fake_popens):
+
+    def wrap(test_func):
+
+        def run_simulated():
+            logger = Mock()
+            with (
+                patch('sys.argv', sys_argv),
+                patch('pip_review.__main__.setup_logging', return_value=logger),
+                patch('subprocess.Popen', side_effect=fake_popens) as popen
+            ):
+                main()
+                test_func(popen, logger)
+
+        return run_simulated
+
+    return wrap
+
+
+UP_TO_DATE = FakePopen(b'[]\r\n')
+
+
+@simulate(
+    [''],
+    [UP_TO_DATE],
+)
+def test_everything_is_up_to_date(popen, logger):
+    assert popen.call_args_list == [outdated_call()]
+    assert logger.mock_calls == [call.info('Everything up-to-date')]
+
+
+@simulate(
+    [''],
+    [
+        FakePopen(
+            b'[{"name": "setuptools", "version": "65.1.1", "latest_version": "65.3.0", "latest_filetype": "wheel"}]\r\n'
+        ),
+    ],
+)
+def test_single_outdated_package(popen, logger):
+    assert popen.call_args_list == [outdated_call()]
+    assert logger.mock_calls == [call.info('setuptools==65.3.0 is available (you have 65.1.1)')]
+
+
+OUTDATED_SETUPTOOLS = FakePopen(
+    b'[{"name": "setuptools", "version": "65.1.1", "latest_version": "65.3.0", "latest_filetype": "wheel"}]\r\n'
+)
+
+
+@simulate(
+    ['', '--raw'],
+    [OUTDATED_SETUPTOOLS],
+)
+def test_raw_option(popen, logger):
+    assert popen.call_args_list == [outdated_call()]
+    assert logger.mock_calls == [call.info('setuptools==65.3.0')]
+
+
+@simulate(
+    ['', '--timeout', '30'],
+    [UP_TO_DATE],
+)
+def test_forwarding_unrecognized_args(popen, logger):
+    assert popen.call_args == outdated_call(['--timeout', '30'])
+    assert logger.mock_calls == [call.info('Everything up-to-date')]
+
+
+def test_forwarding_unrecognized_args_fails():
+    with raises(subprocess.CalledProcessError):
+        simulate(
+            ['', '--bananas'],
+            [FakePopen(b'[]\r\n', returncode=-1)],
+        )(lambda: None)()
+
+
+@simulate(
+    ['', '--auto'],
+    [UP_TO_DATE],
+)
+def test_auto_up_to_date(popen, logger):
+    assert popen.call_args_list == [outdated_call()]
+    assert logger.mock_calls == [call.info('Everything up-to-date')]
+
+
+@simulate(
+    ['', '--auto', '--force-reinstall'],
+    [OUTDATED_SETUPTOOLS, FakePopen()],
+)
+def test_forwarding_to_install_not_list(popen, logger):
+    assert popen.call_args_list[0] == outdated_call()
+    assert popen.call_args_list[1].args[0] == [
+        python, '-m', 'pip', 'install', '-U', '--force-reinstall', 'setuptools']
+    assert popen.call_count == 2
+    logger.assert_not_called()
+
+
+@simulate(
+    ['', '--auto', '--not-required'],
+    [OUTDATED_SETUPTOOLS, FakePopen()],
+)
+def test_forwarding_to_list_not_install(popen, logger):
+    assert popen.call_args_list[0] == outdated_call(['--not-required'])
+    assert popen.call_args.args[0] == [
+        python, '-m', 'pip', 'install', '-U', 'setuptools']
+    assert popen.call_count == 2
+    logger.assert_not_called()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -55,12 +55,10 @@ def simulate(sys_argv, fake_popens):
 
         def run_simulated():
             logger = Mock()
-            with (
-                patch('sys.argv', sys_argv),
-                patch('pip_review.__main__.setup_logging', return_value=logger),
-                patch('subprocess.Popen', CopyingMock(side_effect=fake_popens)) as popen
-            ):
-                main()
+            with patch('subprocess.Popen', CopyingMock(side_effect=fake_popens)) as popen:
+                with patch('pip_review.__main__.setup_logging', return_value=logger):
+                    with patch('sys.argv', sys_argv):
+                        main()
                 test_func(popen, logger)
 
         return run_simulated

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -36,7 +36,7 @@ class CopyingMock(Mock):
     # captured correctly. This class is workaround. See:
     # https://docs.python.org/3/library/unittest.mock-examples.html#coping-with-mutable-arguments
 
-    def __call__(self, /, *args, **kwargs):
+    def __call__(self, *args, **kwargs):
         return super().__call__(*deepcopy(args), **kwargs)
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import subprocess
 from unittest.mock import patch, call, Mock
 from sys import executable as python
@@ -132,7 +133,7 @@ def test_forwarding_to_install_not_list(popen, logger):
     assert popen.call_args_list[1].args[0] == [
         python, '-m', 'pip', 'install', '-U', '--force-reinstall', 'setuptools']
     assert popen.call_count == 2
-    logger.assert_not_called()
+    assert not logger.mock_calls
 
 
 @simulate(
@@ -144,4 +145,4 @@ def test_forwarding_to_list_not_install(popen, logger):
     assert popen.call_args.args[0] == [
         python, '-m', 'pip', 'install', '-U', 'setuptools']
     assert popen.call_count == 2
-    logger.assert_not_called()
+    assert not logger.mock_calls

--- a/tox.ini
+++ b/tox.ini
@@ -4,5 +4,5 @@ envlist = py27,py34,py36,py310
 [testenv]
 deps=cram
 commands=
-    ./run-tests.sh
     pytest
+    ./run-tests.sh

--- a/tox.ini
+++ b/tox.ini
@@ -3,4 +3,6 @@ envlist = py27,py34,py36,py310
 
 [testenv]
 deps=cram
-commands=./run-tests.sh
+commands=
+    ./run-tests.sh
+    pytest


### PR DESCRIPTION
The tests are offline. No actual calling of pip takes place. Basically, we assert that for each given `sys.argv` value, `Popen` is called with the expected `pip list` and `pip install` arguments.

The `simulate` decorator should be applied to test functions. It patches `sys.argv` and mocks `Popen`. The test function should then accept two arguments: `popen`, and  `logger` which can be used for assertion.

I understand that this approach is a lot more complicated than cram. so feel free to reject :)

#61