### PR TITLE
Implement --freeze-outdated-packages argument

### DIFF
--- a/pip_review/__main__.py
+++ b/pip_review/__main__.py
@@ -84,7 +84,7 @@ def parse_args():
         '--continue-on-fail', '-C', action='store_true', default=False,
         help='Continue with other installs when one fails')
     parser.add_argument(
-        '--freeze-outdated-packages', '-f', action='store_true', default=False,
+        '--freeze-outdated-packages', action='store_true', default=False,
         help='Freeze all outdated packages to "requirements.txt" before upgrading them')
     return parser.parse_known_args()
 


### PR DESCRIPTION
This adds a new argument `--freeze-outdated-packages` or `-f` for saving all outdated packages to a `requirements.txt` file before upgrading them.

When used in combination with `--interactive` or `-i`, only the selected packages are saved.

Resolves #97.