### PR TITLE
Code Quality: Global Constants, Organized Imports, Simplified Set Creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ __pycache__
 /build
 *.egg-info
 *.pyc
+
+# Additionally, ignore virtual environments
+venv/

--- a/pip_review/__main__.py
+++ b/pip_review/__main__.py
@@ -50,58 +50,55 @@ Python>=3.3.
 '''
 
 # parameters that pip list supports but not pip install
-LIST_ONLY = set(
-    [
-        'l',
-        'local',
-        'path',
-        'format',
-        'not-required',
-        'exclude-editable',
-        'include-editable',
-    ]
-)
+LIST_ONLY = {
+    'l',
+    'local',
+    'path',
+    'format',
+    'not-required',
+    'exclude-editable',
+    'include-editable',
+}
 
 # parameters that pip install supports but not pip list
-INSTALL_ONLY = set(
-    [
-        'c',
-        'constraint',
-        'no-deps',
-        't',
-        'target',
-        'platform',
-        'python-version',
-        'implementation',
-        'abi',
-        'root',
-        'prefix',
-        'b',
-        'build',
-        'src',
-        'U',
-        'upgrade',
-        'upgrade-strategy',
-        'force-reinstall',
-        'I',
-        'ignore-installed',
-        'ignore-requires-python',
-        'no-build-isolation',
-        'use-pep517',
-        'install-option',
-        'global-option',
-        'compile',
-        'no-compile',
-        'no-warn-script-location',
-        'no-warn-conflicts',
-        'no-binary',
-        'only-binary',
-        'prefer-binary',
-        'no-clean',
-        'require-hashes',
-        'progress-bar',
-    ]
-)
+INSTALL_ONLY = {
+    'c',
+    'constraint',
+    'no-deps',
+    't',
+    'target',
+    'platform',
+    'python-version',
+    'implementation',
+    'abi',
+    'root',
+    'prefix',
+    'b',
+    'build',
+    'src',
+    'U',
+    'upgrade',
+    'upgrade-strategy',
+    'force-reinstall',
+    'I',
+    'ignore-installed',
+    'ignore-requires-python',
+    'no-build-isolation',
+    'use-pep517',
+    'install-option',
+    'global-option',
+    'compile',
+    'no-compile',
+    'no-warn-script-location',
+    'no-warn-conflicts',
+    'no-binary',
+    'only-binary',
+    'prefer-binary',
+    'no-clean',
+    'require-hashes',
+    'progress-bar',
+}
+
 
 # command that sets up the pip module of the current Python interpreter
 PIP_CMD = [sys.executable, '-m', 'pip']

--- a/pip_review/__main__.py
+++ b/pip_review/__main__.py
@@ -51,54 +51,21 @@ Python>=3.3.
 
 # parameters that pip list supports but not pip install
 LIST_ONLY = {
-    'l',
-    'local',
-    'path',
-    'format',
-    'not-required',
-    'exclude-editable',
-    'include-editable',
+    'l', 'local', 'path', 'format', 'not-required',
+    'exclude-editable', 'include-editable',
 }
 
 # parameters that pip install supports but not pip list
 INSTALL_ONLY = {
-    'c',
-    'constraint',
-    'no-deps',
-    't',
-    'target',
-    'platform',
-    'python-version',
-    'implementation',
-    'abi',
-    'root',
-    'prefix',
-    'b',
-    'build',
-    'src',
-    'U',
-    'upgrade',
-    'upgrade-strategy',
-    'force-reinstall',
-    'I',
-    'ignore-installed',
-    'ignore-requires-python',
-    'no-build-isolation',
-    'use-pep517',
-    'install-option',
-    'global-option',
-    'compile',
-    'no-compile',
-    'no-warn-script-location',
-    'no-warn-conflicts',
-    'no-binary',
-    'only-binary',
-    'prefer-binary',
-    'no-clean',
-    'require-hashes',
+    'c', 'constraint', 'no-deps', 't', 'target', 'platform', 'python-version',
+    'implementation', 'abi', 'root', 'prefix', 'b', 'build', 'src', 'U',
+    'upgrade', 'upgrade-strategy', 'force-reinstall', 'I', 'ignore-installed',
+    'ignore-requires-python', 'no-build-isolation', 'use-pep517',
+    'install-option', 'global-option', 'compile', 'no-compile', 
+    'no-warn-script-location', 'no-warn-conflicts', 'no-binary', 
+    'only-binary', 'prefer-binary', 'no-clean', 'require-hashes',
     'progress-bar',
 }
-
 
 # command that sets up the pip module of the current Python interpreter
 PIP_CMD = [sys.executable, '-m', 'pip']

--- a/pip_review/__main__.py
+++ b/pip_review/__main__.py
@@ -106,7 +106,7 @@ INSTALL_ONLY = set(
 # command that sets up the pip module of the current Python interpreter
 PIP_CMD = [sys.executable, '-m', 'pip']
 
-# Nicer headings for the columns in the oudated package table
+# nicer headings for the columns in the oudated package table
 COLUMNS = {
     'Package': 'name',
     'Version': 'version',

--- a/pip_review/__main__.py
+++ b/pip_review/__main__.py
@@ -50,10 +50,58 @@ Python>=3.3.
 '''
 
 # parameters that pip list supports but not pip install
-LIST_ONLY = set('l local path format not-required exclude-editable include-editable'.split())
+LIST_ONLY = set(
+    [
+        'l',
+        'local',
+        'path',
+        'format',
+        'not-required',
+        'exclude-editable',
+        'include-editable',
+    ]
+)
 
 # parameters that pip install supports but not pip list
-INSTALL_ONLY = set('c constraint no-deps t target platform python-version implementation abi root prefix b build src U upgrade upgrade-strategy force-reinstall I ignore-installed ignore-requires-python no-build-isolation use-pep517 install-option global-option compile no-compile no-warn-script-location no-warn-conflicts no-binary only-binary prefer-binary no-clean require-hashes progress-bar'.split())
+INSTALL_ONLY = set(
+    [
+        'c',
+        'constraint',
+        'no-deps',
+        't',
+        'target',
+        'platform',
+        'python-version',
+        'implementation',
+        'abi',
+        'root',
+        'prefix',
+        'b',
+        'build',
+        'src',
+        'U',
+        'upgrade',
+        'upgrade-strategy',
+        'force-reinstall',
+        'I',
+        'ignore-installed',
+        'ignore-requires-python',
+        'no-build-isolation',
+        'use-pep517',
+        'install-option',
+        'global-option',
+        'compile',
+        'no-compile',
+        'no-warn-script-location',
+        'no-warn-conflicts',
+        'no-binary',
+        'only-binary',
+        'prefer-binary',
+        'no-clean',
+        'require-hashes',
+        'progress-bar',
+    ]
+)
 
 # command that sets up the pip module of the current Python interpreter
 PIP_CMD = [sys.executable, '-m', 'pip']

--- a/pip_review/__main__.py
+++ b/pip_review/__main__.py
@@ -181,17 +181,17 @@ def setup_logging(verbose):
     else:
         level = logging.INFO
 
-    format = u'%(message)s'
+    format_ = u'%(message)s'
 
     logger = logging.getLogger(u'pip-review')
 
     stdout_handler = logging.StreamHandler(sys.stdout)
     stdout_handler.addFilter(StdOutFilter())
-    stdout_handler.setFormatter(logging.Formatter(format))
+    stdout_handler.setFormatter(logging.Formatter(format_))
     stdout_handler.setLevel(logging.DEBUG)
 
     stderr_handler = logging.StreamHandler(sys.stderr)
-    stderr_handler.setFormatter(logging.Formatter(format))
+    stderr_handler.setFormatter(logging.Formatter(format_))
     stderr_handler.setLevel(logging.WARNING)
 
     logger.setLevel(level)


### PR DESCRIPTION
Made some (minor) adjustments:
1. Replaced the functions ``pip_cmd`` and ``version_epilog`` with global constants ``PIP_CMD`` and ``VERSION_EPILOG``, since function calls in Python are quite expensive (although it probably won’t make much of a difference) and I find it to be more readable. All global constants are now also declared  at the top of the module.
2. Removed unnecessary ``PY3`` constant assignment
3. Sorted imports according to [PEP8](https://peps.python.org/pep-0008/#imports).
4. Simplified set creation for ``LIST_ONLY`` and ``INSTALL_ONLY``
5. Renamed ``format`` to ``format_`` to avoid clashing with built-in function
6. Replaced existing ``.gitignore`` with a template for Python projects