### PR TITLE
Configs And Docs: Add ``.editorconfig`` and update guidelines in ``CONTRIBUTING.md``

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# https://editorconfig.org/
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+end_of_line = crlf
+insert_final_newline = true
+
+[*.py]
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ charset = utf-8
 indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
-end_of_line = crlf
+end_of_line = lf
 insert_final_newline = true
 
 [*.py]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,6 @@ Any kind of contribution is welcome; nothing is "off limits". However, for those
 
 This repo ([jgonggrijp/pip-review](https://github.com/jgonggrijp/pip-review)) uses [gitflow](https://github.com/nvie/gitflow). Please submit pull requests to the `develop` branch.
 
-The Python files use 4-space soft tabs. The other files use 2-space soft tabs.
+To maintain consistent coding style and formatting across the project, an [``EditorConfig`` file](/.editorconfig) has been set up, in order to guarantee that all contributors use the same settings for indentation, character encoding, line endings etc.
 
-Please ensure that lines of code do not exceed a **maximum length of 79 characters** to maintain code readability and consistency throughout the project.
+Additionally, please ensure that lines of code do not exceed a **maximum length of 79 characters** to further enhance readability and consistency of the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,3 +17,5 @@ Any kind of contribution is welcome; nothing is "off limits". However, for those
 This repo ([jgonggrijp/pip-review](https://github.com/jgonggrijp/pip-review)) uses [gitflow](https://github.com/nvie/gitflow). Please submit pull requests to the `develop` branch.
 
 The Python files use 4-space soft tabs. The other files use 2-space soft tabs.
+
+Please ensure that lines of code do not exceed a **maximum length of 79 characters** to maintain code readability and consistency throughout the project.


### PR DESCRIPTION
Suggesting the addition of a guideline to ``CONTRIBUTING.md`` for maintaining code consistency by adhering to a maximum line length of 79 characters.