### PR TITLE
Fixes #114

### DIFF
--- a/pip_review/__main__.py
+++ b/pip_review/__main__.py
@@ -53,6 +53,7 @@ Python>=3.3.
 LIST_ONLY = {
     'l', 'local', 'path', 'format', 'not-required',
     'exclude-editable', 'include-editable',
+    'exclude',
 }
 
 # parameters that pip install supports but not pip list


### PR DESCRIPTION
Result of `./run_tests.sh`:
```
$ ./run-tests.sh 
.
# Ran 1 tests, 0 skipped, 0 failed.
```

I created a Python venv to install cram, as ISTR you mentioned moving from cram to pytest or some such?
