### PR TITLE
Added pinned pkgs info#103

### DIFF
--- a/pip_review/__main__.py
+++ b/pip_review/__main__.py
@@ -9,7 +9,6 @@ import sys
 from functools import partial
 from operator import itemgetter
 from os import environ as os_environ
-from os import path as os_path
 
 import pip
 from packaging import version
@@ -86,7 +85,9 @@ VERSION_EPILOG = DEPRECATED_NOTICE if (2, 7) > sys.version_info >= (3, 3) else '
 
 
 def parse_args():
-    description = 'Keeps your Python packages fresh. Looking for a new maintainer! See https://github.com/jgonggrijp/pip-review/issues/76'
+    description = 'Keeps your Python packages fresh. \
+                   Looking for a new maintainer! \
+                   See https://github.com/jgonggrijp/pip-review/issues/76'
     parser = argparse.ArgumentParser(
         description=description,
         epilog=EPILOG + VERSION_EPILOG,
@@ -178,7 +179,8 @@ class InteractiveAsker(object):
 
         answer = ''
         while answer not in ['y', 'n', 'a', 'q']:
-            question_last='{0} [Y]es, [N]o, [A]ll, [Q]uit ({1}) '.format(prompt, self.last_answer)
+            question_last='{0} [Y]es, [N]o, [A]ll, [Q]uit ({1}) '\
+                .format(prompt, self.last_answer)
             question_default='{0} [Y]es, [N]o, [A]ll, [Q]uit '.format(prompt)
             answer = input(question_last if self.last_answer else question_default)
             answer = answer.strip().lower()
@@ -193,14 +195,32 @@ class InteractiveAsker(object):
 
 ask_to_install = partial(InteractiveAsker().ask, prompt='Upgrade now?')
 
+
+def get_constraint_filename(list_args):
+    # TODO: Obtain from cmdline arg "-c, --constraint"  just like pip?
+    # Q: Which takes precedence : env var or cmdline? Standard would be
+    # cmdline arg has precedence, so let's check that first and fall
+    # back to env var if needed
+    # Something like: if list_args.constraint: ... else: env.get() ...
+    return os_environ.get("PIP_CONSTRAINT", "")
+
+
 def get_constrained_packages(constraint_file):
+    # TODO: we could probably pass this to PIP_CMD instead? I need to check.
     constrained_packages = []
-    if os_path.isfile(constraint_file):
-        with open(constraint_file, "r") as f:
-            for line in f:
-                if "==" in line:
-                    constrained_packages.append(line.split("==")[0].strip())
+    # open() will throw exception if "constraint_file" is not a readable file
+    # It is a user-supplied param so we should at least log if there is an issue
+    # Allow exceptions to propgate from here and catch at point-of-call
+    with open(constraint_file, "r") as f:
+        for line in f:
+            line.strip()
+            # '#' at begin of line is a comment line in constraints file
+            # It would be a nasty bug if someone commented-out a constraint
+            # line but we included it anyway...
+            if not line.startswith("#") and "==" in line:
+                constrained_packages.append(line.split("==")[0].strip())
     return constrained_packages
+
 
 def update_packages(packages, forwarded, continue_on_fail, freeze_outdated_packages):
     upgrade_cmd = PIP_CMD + ['install', '-U'] + forwarded
@@ -297,8 +317,16 @@ def main():
     if args.raw and args.interactive:
         raise SystemExit('--raw and --interactive cannot be used together')
 
-    constraint_file = os_environ.get("PIP_CONSTRAINT", "")
-    constrained_packages = get_constrained_packages(constraint_file)
+    constrained_packages = []
+    constraint_filename = get_constraint_filename(list_args)
+    try:
+        constrained_packages = get_constrained_packages(constraint_filename)
+    except FileNotFoundError:
+        logger.warning("The constraint file \"{0}\" was not found."\
+                       .format(constraint_filename))
+    except IOError:
+        logger.warning("Constraint file \"{0}\" could not be read."\
+                       .format(constraint_filename))
 
     outdated = get_outdated_packages(list_args)
     if not outdated and not args.raw:
@@ -309,34 +337,40 @@ def main():
         if args.preview_only:
             return
     if args.auto:
-        update_packages(outdated, install_args, args.continue_on_fail, args.freeze_outdated_packages)
+        update_packages(outdated,
+                        install_args,
+                        args.continue_on_fail,
+                        args.freeze_outdated_packages)
         return
     if args.raw:
         if not outdated:
             logger.info('Everything up-to-date')
         else:
             for pkg in outdated:
-                logger.info('{0}=={1}'.format(pkg['name'], pkg['latest_version']))
+                logger.info('{0}=={1}'\
+                            .format(pkg['name'], pkg['latest_version']))
         return
 
     selected = []
     for pkg in outdated:
-        logger.info('{0}=={1} is available (you have {2})'.format(
-            pkg['name'], pkg['latest_version'], pkg['version']
-        ))
+        msg = "{0}=={1} is available (you have {2}"
         if pkg["name"] in constrained_packages:
-            logger.info(
-                "{0}=={1} is available (you have {2}, constrained".format(
-                    pkg["name"],
-                    pkg["latest_version"],
-                    pkg["version"]))
+            msg = msg + ", constrained)."
+        else:
+            msg = msg + ').'
+        logger.info(msg.format(pkg["name"],
+                               pkg["latest_version"],
+                               pkg["version"]))
+
         if args.interactive:
             answer = ask_to_install()
             if answer in ['y', 'a']:
                 selected.append(pkg)
     if selected:
-        update_packages(selected, install_args, args.continue_on_fail, args.freeze_outdated_packages)
-
+        update_packages(selected,
+                        install_args,
+                        args.continue_on_fail,
+                        args.freeze_outdated_packages)
 
 if __name__ == '__main__':
     try:

--- a/pip_review/__main__.py
+++ b/pip_review/__main__.py
@@ -324,14 +324,12 @@ def main():
         logger.info('{0}=={1} is available (you have {2})'.format(
             pkg['name'], pkg['latest_version'], pkg['version']
         ))
-        constrained_text = " [Constrained]" if pkg["name"] in constrained_packages else ""
-        if constrained_text:
+        if pkg["name"] in constrained_packages:
             logger.info(
-                "{0}=={1} is available (you have {2}){3}".format(
+                "{0}=={1} is available (you have {2}, constrained".format(
                     pkg["name"],
                     pkg["latest_version"],
-                    pkg["version"],
-                    constrained_text))
+                    pkg["version"]))
         if args.interactive:
             answer = ask_to_install()
             if answer in ['y', 'a']:

--- a/pip_review/__main__.py
+++ b/pip_review/__main__.py
@@ -53,6 +53,7 @@ Python>=3.3.
 LIST_ONLY = {
     'l', 'local', 'path', 'format', 'not-required',
     'exclude-editable', 'include-editable',
+    'exclude',
 }
 
 # parameters that pip install supports but not pip list

--- a/pip_review/__main__.py
+++ b/pip_review/__main__.py
@@ -8,6 +8,8 @@ import subprocess
 import sys
 from functools import partial
 from operator import itemgetter
+from os import environ as os_environ
+from os import path as os_path
 
 import pip
 from packaging import version
@@ -191,6 +193,14 @@ class InteractiveAsker(object):
 
 ask_to_install = partial(InteractiveAsker().ask, prompt='Upgrade now?')
 
+def get_constrained_packages(constraint_file):
+    constrained_packages = []
+    if os_path.isfile(constraint_file):
+        with open(constraint_file, "r") as f:
+            for line in f:
+                if "==" in line:
+                    constrained_packages.append(line.split("==")[0].strip())
+    return constrained_packages
 
 def update_packages(packages, forwarded, continue_on_fail, freeze_outdated_packages):
     upgrade_cmd = PIP_CMD + ['install', '-U'] + forwarded
@@ -287,6 +297,9 @@ def main():
     if args.raw and args.interactive:
         raise SystemExit('--raw and --interactive cannot be used together')
 
+    constraint_file = os_environ.get("PIP_CONSTRAINT", "")
+    constrained_packages = get_constrained_packages(constraint_file)
+
     outdated = get_outdated_packages(list_args)
     if not outdated and not args.raw:
         logger.info('Everything up-to-date')
@@ -299,8 +312,11 @@ def main():
         update_packages(outdated, install_args, args.continue_on_fail, args.freeze_outdated_packages)
         return
     if args.raw:
-        for pkg in outdated:
-            logger.info('{0}=={1}'.format(pkg['name'], pkg['latest_version']))
+        if not outdated:
+            logger.info('Everything up-to-date')
+        else:
+            for pkg in outdated:
+                logger.info('{0}=={1}'.format(pkg['name'], pkg['latest_version']))
         return
 
     selected = []
@@ -308,6 +324,14 @@ def main():
         logger.info('{0}=={1} is available (you have {2})'.format(
             pkg['name'], pkg['latest_version'], pkg['version']
         ))
+        constrained_text = " [Constrained]" if pkg["name"] in constrained_packages else ""
+        if constrained_text:
+            logger.info(
+                "{0}=={1} is available (you have {2}){3}".format(
+                    pkg["name"],
+                    pkg["latest_version"],
+                    pkg["version"],
+                    constrained_text))
         if args.interactive:
             answer = ask_to_install()
             if answer in ['y', 'a']:


### PR DESCRIPTION
1. This is only a partial push for 103, I'll address each of the review requests with a separate commit/ push:

2. I rebased this branch onto fix for #114, assuming #114 is ok

3. I manually merged the code changes already submitted by [EaglePPP](https://github.com/EaglePPP) June 2023 (is now July 2026, but never too late I guess!). The `__main__.py` had changed somewhat since June 2023 and the overall mods were not that massive...

4. There seems to have been some kind of regression when running the tests around (current) lines 303 - 320 in `__main__.py`.

The test was failing for `pip-review --raw` for the simulated out-of-date `dateutils` package. The non-raw printed "Everything up-to-date". The `--raw` version printed nothing. Turned out that lines 304ff in `__main.py__`:
```python
if not outdated and not args.raw:
    logger.info('Everything up-to-date')
    return
```
are fine for the non-raw case, but for the `--raw` case in lines 314 ff we had:
```python
if args.raw:
    for pkg in outdated:
        logger.info('{0}=={1}'.format(pkg['name'], pkg['latest_version']))
```
And what happens when `outdated` is (for the test case) correctly empty? The for loop doesn't execute - which gave us no output and hence the test fail.

So I modded the code to look like this:
```python
if args.raw:
    if not outdated:
        logger.info('Everything up-to-date')
    else:
        for pkg in outdated:
            logger.info('{0}=={1}'.format(pkg['name'], pkg['latest_version']))
    return
```

Needed package imports added at top... `os` is a huge beast so I tend to do `from os import NNN` if I'm only using a small part of the package.

Still some more to come: adding support for the correct reporting (your point 3) and adding the test to review.t, also supplying a test constraint file set by env var PIP_CONSTRAINT (based on your earlier comments, do you want to change this env var name and/or use a straight cmdline arg instead of env var?)

Hope that's ok with you so far.

Oh, yeah, ./run_tests.sh now gives:

```shell
$ ./run-tests.sh 
.
# Ran 1 tests, 0 skipped, 0 failed.
```

